### PR TITLE
newly-set commit_ts only need to be compared with the first commit_ts

### DIFF
--- a/utilities/transactions/totransaction_db_impl.cc
+++ b/utilities/transactions/totransaction_db_impl.cc
@@ -92,7 +92,7 @@ Status TOTransactionDBImpl::UnCommittedKeys::CheckKeyAndAddInLock(const Slice& k
   auto addedSize =
     mem_usage->load(std::memory_order_relaxed) + key.size() + sizeof(txn_id);
   if (addedSize > max_mem_usage) {
-    ROCKS_LOG_WARN(info_log_, "TOTDB WriteConflict mem usage(%ll) is greater than limit(%llu) \n",
+    ROCKS_LOG_WARN(info_log_, "TOTDB WriteConflict mem usage(%llu) is greater than limit(%llu) \n",
       addedSize, max_mem_usage);
     return Status::Busy();
   }
@@ -367,10 +367,6 @@ Status TOTransactionDBImpl::AddCommitQueue(const std::shared_ptr<ATN>& core,
   if (core->commit_ts_set_) {
     if (ts < core->first_commit_ts_) {
       return Status::InvalidArgument("commit-ts smaller than first-commit-ts");
-    }
-    if (ts < core->commit_ts_) {
-      // in wt3.0, there is no restriction like this one.
-      return Status::InvalidArgument("commit-ts must be monotonic in a txn");
     }
     core->commit_ts_ = ts;
     return Status::OK();

--- a/utilities/transactions/totransaction_impl.cc
+++ b/utilities/transactions/totransaction_impl.cc
@@ -88,17 +88,6 @@ Status TOTransactionImpl::SetCommitTimeStamp(const RocksTimeStamp& timestamp) {
     return Status::NotSupported("not allowed to set committs to 0");
   }
 
-  if (core_->commit_ts_set_) {
-    if (core_->commit_ts_ > timestamp) {
-      return Status::NotSupported("commit ts need equal with the pre set");
-    }
-    if (core_->commit_ts_ == timestamp) {
-      return Status::OK();
-    }
-  }
-
-  assert((!core_->commit_ts_set_) || core_->commit_ts_ < timestamp);
-
   // publish commit_ts to global view
   auto s = txn_db_impl_->AddCommitQueue(core_, timestamp);
   if (!s.ok()) {


### PR DESCRIPTION
See `__wt_timestamp_validate` in wiredtiger

Signed-off-by: baiwfg2 <baiwfg2@gmail.com>